### PR TITLE
Changing teavm repository from Maven central to bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It goes like this (every value is the default):
        classFiles = null;
        
        compileScopes = null;
-       minifying = true;
+       obfuscated = true;
        maxTopLevelNames = 10000;
        properties = null;
        debugInformationGenerated = false;

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,12 @@ buildscript {
     }
 }
 
-repositories { jcenter() }
+repositories { 
+	jcenter()
+    maven {
+        url  "https://dl.bintray.com/konsoletyper/teavm" 
+    }
+}
 
 dependencies {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-teavmVersion = 0.6.1
+teavmVersion = 0.7.0-dev-1087
 
 groupId = io.github.zebalu
 version = 1.0.0

--- a/src/main/java/io/github/zebalu/gradle/teavm/TeavmCompileExecutor.java
+++ b/src/main/java/io/github/zebalu/gradle/teavm/TeavmCompileExecutor.java
@@ -63,13 +63,14 @@ class TeavmCompileExecutor {
         buildStrategy.setClassPathEntries(prepareClassPath());
         buildStrategy.setDebugInformationGenerated(settings.isDebugInformationGenerated());
         buildStrategy.setEntryPointName(settings.getEntryPointName());
-        buildStrategy.setHeapSize(settings.getMaxHeapSize());
+        buildStrategy.setMaxHeapSize(settings.getMaxHeapSize());
+        buildStrategy.setMinHeapSize(settings.getMinHeapSize());
         buildStrategy.setIncremental(settings.isIncremental());
         buildStrategy.setLog(new Slf4JTeavmLog(TeavmCompileTask.class));
         buildStrategy.setLongjmpSupported(settings.isLongjmpSupported());
         buildStrategy.setMainClass(settings.getMainClass());
         buildStrategy.setMaxTopLevelNames(settings.getMaxTopLevelNames());
-        buildStrategy.setMinifying(settings.isMinifying());
+        buildStrategy.setObfuscated(settings.isObfuscated());
         buildStrategy.setOptimizationLevel(settings.getOptimizationLevel());
         buildStrategy.setProgressListener(new LoggingProgressListener(LOG));
         if (settings.getProperties() != null) {

--- a/src/main/java/io/github/zebalu/gradle/teavm/TeavmExtension.java
+++ b/src/main/java/io/github/zebalu/gradle/teavm/TeavmExtension.java
@@ -47,7 +47,7 @@ public class TeavmExtension implements Serializable {
 
     private List<String> compileScopes = null;
 
-    private boolean minifying = true;
+    private boolean obfuscated = true;
 
     private int maxTopLevelNames = 10000;
 
@@ -144,12 +144,28 @@ public class TeavmExtension implements Serializable {
         this.compileScopes = compileScopes;
     }
 
-    public boolean isMinifying() {
-        return minifying;
+    public boolean isObfuscated() {
+    	return obfuscated;
     }
 
+    public void setObfuscated(boolean obfuscated) {
+        this.obfuscated = obfuscated;
+    }
+    
+    @Deprecated
+    /**
+     * @deprecated Use isObfuscated instead
+     */
+    public boolean isMinifying() {
+        return obfuscated;
+    }
+
+    @Deprecated
+    /**
+     * @deprecated Use setObfuscated instead
+     */
     public void setMinifying(boolean minifying) {
-        this.minifying = minifying;
+        this.obfuscated = minifying;
     }
 
     /**


### PR DESCRIPTION
It seems that the official teavm repository is on bintray. This commit
sets up the teavm bintray repository and switches the version to the
current latest on bintray (0.7.0-dev-1087)
Also handles the incompatible changes:
 - minifying became obfuscated
 - unified heap size setup became separeted to min and max