### PR TITLE
added support to create a JavaScript module that's e.g. usable in NodeJS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,18 +5,20 @@ apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'dev.gradleplugins.java-gradle-plugin'
 apply plugin: 'java-gradle-plugin'
 
-java.sourceCompatibility='VERSION_1_8'
-java.targetCompatibility='VERSION_1_8'
+java.sourceCompatibility = 'VERSION_1_8'
+java.targetCompatibility = 'VERSION_1_8'
 
 buildscript {
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
-        classpath 'com.gradle.publish:plugin-publish-plugin:0.10.1'
-        classpath 'dev.gradleplugins:gradle-plugin-development:0.0.21'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.12.0'
+        classpath 'dev.gradleplugins:gradle-plugin-development:1.1'
     }
     repositories {
         jcenter()
-        maven { url 'https://plugins.gradle.org/m2/' }
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 }
 
@@ -36,14 +38,13 @@ dependencies {
     testCompile group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
     // https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
     testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.1.0'
-    
+
     testImplementation gradleTestKit()
-    
+
     // https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine
     testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.5.2'
-    
-    
-    
+
+
 }
 
 test {
@@ -59,6 +60,10 @@ gradlePlugin {
             implementationClass = 'io.github.zebalu.gradle.teavm.TeavmGradlePlugin'
         }
     }
+}
+
+task functionalTestClasses() {
+
 }
 
 task sourcesJar(type: Jar) {
@@ -101,9 +106,6 @@ def pomConfig = {
 publishing {
     publications {
         maven(MavenPublication) {
-            groupId = 'io.github.zebalu'
-            artifactId = project.name
-            version = version
 
             from components.java
             artifact sourcesJar
@@ -133,15 +135,6 @@ bintray {
     }
 }
 
-gradlePlugin {
-    plugins {
-        teavmPlugin {
-            id = 'io.github.zebalu.teavm-gradle-plugin'
-            implementationClass = 'io.github.zebalu.gradle.teavm.TeavmGradlePlugin'
-        }
-    }
-}
-
 pluginBundle {
     website = 'https://github.com/zebalu/teavm-gradle-plugin'
     vcsUrl = 'https://github.com/zebalu/teavm-gradle-plugin'
@@ -154,17 +147,17 @@ pluginBundle {
             tags = ['teavm', 'bytecode', 'javascript', 'transpile']
         }
     }
-    
+
     mavenCoordinates {
-        groupId = project.groupId
+        groupId = project.group
         artifactId = project.name
         version = project.version
-      }
+    }
 }
 
 
 String getPropertyOrWarn(String propertyName) {
-    if ( !project.hasProperty(propertyName) ) {
+    if (!project.hasProperty(propertyName)) {
         logger.warn("There is no property set with name: ${propertyName}. Publication might fail.")
         return 'missing'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 teavmVersion = 0.6.1
 
-groupId = io.github.zebalu
-version = 1.0.0
+group = io.github.zebalu
+name = teavm-gradle-plugin
+version = 1.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/zebalu/gradle/teavm/TeavmExtension.java
+++ b/src/main/java/io/github/zebalu/gradle/teavm/TeavmExtension.java
@@ -105,6 +105,8 @@ public class TeavmExtension implements Serializable {
 
     private boolean skipJavaCompile = false;
 
+    private boolean createModuleExports = false;
+
     /**
      * List of (jar)files/folders where input .class files can be found.
      * 
@@ -278,6 +280,14 @@ public class TeavmExtension implements Serializable {
 
     public void setEntryPointName(String entryPointName) {
         this.entryPointName = entryPointName;
+    }
+
+    public boolean isCreateModuleExports() {
+        return createModuleExports;
+    }
+
+    public void setCreateModuleExports(boolean createModuleExports) {
+        this.createModuleExports = createModuleExports;
     }
 
     public String[] getClassesToPreserve() {


### PR DESCRIPTION
I started using TeaVM to use an existing library in a NodeJS project. Luckily, it works quite out-of-the-box but requires a thin header for the module export. With this pull request, I added a flag to include it.